### PR TITLE
Tolerant stack-map lookup and frame-pointer preservation for reliable GC root collection

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "force-frame-pointers=yes"]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cranelift_codegen::{ir::types::{F64, I8, I64}, isa::{OwnedTargetIsa, TargetIsa}};
+use cranelift_codegen::{ir::types::{F64, I8, I64}, isa::{OwnedTargetIsa, TargetIsa}, settings::Configurable};
 //use cranelift_jit::{JITBuilder, JITModule};
 //use cranelift_module::{FuncId, Module};
 use target_lexicon::Triple;
@@ -134,7 +134,10 @@ pub struct JitContext {
 
 impl JitContext {
     pub fn new(builtins: Builtins) -> Self {
-        let shared_builder = cranelift_codegen::settings::builder();
+        let mut shared_builder = cranelift_codegen::settings::builder();
+        shared_builder
+            .set("preserve_frame_pointers", "true")
+            .expect("failed to enable frame pointers for stack-root walking");
         let shared_flags = cranelift_codegen::settings::Flags::new(shared_builder);
         let triple = Triple::host();
         let isa = cranelift_codegen::isa::lookup(triple)

--- a/src/runtime/stack_roots.rs
+++ b/src/runtime/stack_roots.rs
@@ -1,4 +1,6 @@
-use super::StackMaps;
+use super::{StackMap, StackMaps};
+
+const RETURN_ADDRESS_LOOKBACK_WINDOW: usize = 16;
 
 fn read_word(addr: usize) -> Option<usize> {
     if addr == 0 || !addr.is_multiple_of(core::mem::align_of::<usize>()) {
@@ -8,8 +10,23 @@ fn read_word(addr: usize) -> Option<usize> {
     Some(unsafe { *(addr as *const usize) })
 }
 
+fn find_stack_map<'a>(stack_maps: &'a StackMaps, return_address: usize) -> Option<&'a StackMap> {
+    if let Some(stack_map) = stack_maps.lr_map.get(&return_address) {
+        return Some(stack_map);
+    }
+
+    for delta in 1..=RETURN_ADDRESS_LOOKBACK_WINDOW {
+        let key = return_address.checked_sub(delta)?;
+        if let Some(stack_map) = stack_maps.lr_map.get(&key) {
+            return Some(stack_map);
+        }
+    }
+
+    None
+}
+
 pub fn collect_roots(stack_maps: &StackMaps, fp: usize) -> Vec<usize> {
-    let Some(mut lr) = read_word(fp + 8) else {
+    let Some(mut return_address) = read_word(fp + 8) else {
         return Vec::new();
     };
     let Some(mut fp) = read_word(fp) else {
@@ -19,7 +36,7 @@ pub fn collect_roots(stack_maps: &StackMaps, fp: usize) -> Vec<usize> {
     let mut stack_roots = Vec::new();
 
     while fp != 0 {
-        if let Some(stack_map) = stack_maps.lr_map.get(&lr) {
+        if let Some(stack_map) = find_stack_map(stack_maps, return_address) {
             for offset in &stack_map.map {
                 let addr = fp - stack_map.frame_to_fp_offset + (*offset as usize);
                 if let Some(value) = read_word(addr) {
@@ -28,7 +45,7 @@ pub fn collect_roots(stack_maps: &StackMaps, fp: usize) -> Vec<usize> {
             }
         }
 
-        let Some(next_lr) = read_word(fp + 8) else {
+        let Some(next_return_address) = read_word(fp + 8) else {
             break;
         };
 
@@ -36,9 +53,61 @@ pub fn collect_roots(stack_maps: &StackMaps, fp: usize) -> Vec<usize> {
             break;
         };
 
-        lr = next_lr;
+        return_address = next_return_address;
         fp = next_fp;
     }
 
     stack_roots
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{find_stack_map, StackMap, StackMaps};
+
+    #[test]
+    fn finds_stack_map_with_exact_return_address_match() {
+        let mut lr_map = HashMap::new();
+        lr_map.insert(
+            0x1000,
+            StackMap {
+                map: vec![8],
+                frame_to_fp_offset: 16,
+            },
+        );
+        let stack_maps = StackMaps { lr_map };
+
+        assert!(find_stack_map(&stack_maps, 0x1000).is_some());
+    }
+
+    #[test]
+    fn finds_stack_map_with_small_return_address_delta() {
+        let mut lr_map = HashMap::new();
+        lr_map.insert(
+            0x1000,
+            StackMap {
+                map: vec![8],
+                frame_to_fp_offset: 16,
+            },
+        );
+        let stack_maps = StackMaps { lr_map };
+
+        assert!(find_stack_map(&stack_maps, 0x1005).is_some());
+    }
+
+    #[test]
+    fn does_not_match_when_return_address_delta_is_too_large() {
+        let mut lr_map = HashMap::new();
+        lr_map.insert(
+            0x1000,
+            StackMap {
+                map: vec![8],
+                frame_to_fp_offset: 16,
+            },
+        );
+        let stack_maps = StackMaps { lr_map };
+
+        assert!(find_stack_map(&stack_maps, 0x1011).is_none());
+    }
 }


### PR DESCRIPTION
### Motivation
- The GC root collector was missing roots because it relied on exact return-address-to-stack-map matches and omitted frame pointers could break frame-pointer chain walking. 
- On x86_64 variable-length call encodings and codegen offsets can produce small skews between saved return addresses and stack-map keys, so the collector must both preserve frame pointers and be tolerant to small return-address deltas. 

### Description
- Enable Cranelift frame-pointer preservation by setting `preserve_frame_pointers = true` when constructing the shared ISA flags in `JitContext::new` and import `settings::Configurable` to use the `set` API. 
- Add a workspace build config file `.cargo/config.toml` that sets `rustflags = ["-C", "force-frame-pointers=yes"]` to force frame pointers for Rust runtime frames. 
- Make stack-map resolution tolerant by adding `find_stack_map` in `src/runtime/stack_roots.rs` which first tries an exact return-address match and then scans a small lookback window (`RETURN_ADDRESS_LOOKBACK_WINDOW = 16`) to accept nearby keys, and rename `lr` to `return_address` in `collect_roots` for clarity. 
- Add unit tests in `src/runtime/stack_roots.rs` that cover exact matches, small return-address deltas, and out-of-window mismatches. 

### Testing
- Ran `cargo test` and all unit tests completed successfully. 
- Added and exercised three new tests for `find_stack_map` (exact match, small-delta match, and too-large-delta rejection) and they passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f4e4728c8320b19c2722820cce1e)