### PR TITLE
Add struct method coverage tests for success and failure scenarios

### DIFF
--- a/tests/failure/struct_method_called_on_type.luna
+++ b/tests/failure/struct_method_called_on_type.luna
@@ -1,0 +1,11 @@
+struct Counter {
+    value: int,
+
+    func increment() {
+        self.value = self.value + 1;
+    }
+}
+
+func main() {
+    Counter.increment();
+}

--- a/tests/failure/struct_method_called_with_instance_argument.luna
+++ b/tests/failure/struct_method_called_with_instance_argument.luna
@@ -1,0 +1,12 @@
+struct Counter {
+    value: int,
+
+    func increment() {
+        self.value = self.value + 1;
+    }
+}
+
+func main() {
+    let c = Counter { value: 0 };
+    Counter.increment(c);
+}

--- a/tests/failure/struct_method_missing.luna
+++ b/tests/failure/struct_method_missing.luna
@@ -1,0 +1,8 @@
+struct User {
+    id: int,
+}
+
+func main() {
+    let user = User { id: 42 };
+    user.deactivate();
+}

--- a/tests/failure/struct_self_outside_method.luna
+++ b/tests/failure/struct_self_outside_method.luna
@@ -1,0 +1,11 @@
+struct Item {
+    value: int,
+}
+
+func invalid_use_of_self() {
+    let v = self.value;
+}
+
+func main() {
+    invalid_use_of_self();
+}

--- a/tests/success/struct_methods_nested.luna
+++ b/tests/success/struct_methods_nested.luna
@@ -1,0 +1,33 @@
+struct Engine {
+    rpm: int,
+
+    func rev(amount: int) {
+        self.rpm = self.rpm + amount;
+    }
+
+    func assert_rpm(expected: int) {
+        assert(self.rpm == expected);
+    }
+}
+
+struct Car {
+    engine: Engine,
+
+    func warm_up() {
+        self.engine.rev(300);
+        self.engine.rev(500);
+    }
+
+    func assert_ready() {
+        self.engine.assert_rpm(800);
+    }
+}
+
+func main() {
+    let car = Car {
+        engine: Engine { rpm: 0 }
+    };
+
+    car.warm_up();
+    car.assert_ready();
+}

--- a/tests/success/struct_methods_self_calls.luna
+++ b/tests/success/struct_methods_self_calls.luna
@@ -1,0 +1,26 @@
+struct Accumulator {
+    total: int,
+
+    func add(value: int) {
+        self.total = self.total + value;
+    }
+
+    func add_twice(value: int) {
+        self.add(value);
+        self.add(value);
+    }
+
+    func assert_total(expected: int) {
+        assert(self.total == expected);
+    }
+}
+
+func main() {
+    let acc = Accumulator { total: 0 };
+
+    acc.add(3);
+    acc.assert_total(3);
+
+    acc.add_twice(4);
+    acc.assert_total(11);
+}


### PR DESCRIPTION
### Motivation
- Add comprehensive tests to exercise the newly added struct method feature including valid uses and common failure modes.
- Ensure coverage for methods that call other methods via `self`, nested struct method dispatch through fields, and incorrect usages like `self` outside methods or invalid invocation forms.

### Description
- Added success test `tests/success/struct_methods_self_calls.luna` which verifies an `Accumulator` struct where methods call other methods via `self` and state updates are asserted.
- Added success test `tests/success/struct_methods_nested.luna` which verifies nested struct method calls (`Car` -> `Engine`) and corresponding assertions.
- Added failure test `tests/failure/struct_self_outside_method.luna` that uses `self` in a non-method function and should fail.
- Added failure tests `tests/failure/struct_method_missing.luna`, `tests/failure/struct_method_called_on_type.luna`, and `tests/failure/struct_method_called_with_instance_argument.luna` to cover calling nonexistent methods, invoking a method on a struct type (not an instance), and calling a method by passing an instance to the type-level method respectively.

### Testing
- Ran `cargo build` which completed successfully.
- Executed the new success tests with `./target/debug/luna-rs tests/success/struct_methods_self_calls.luna` and `./target/debug/luna-rs tests/success/struct_methods_nested.luna`, both exited with status `0` indicating success.
- Executed the new failure tests and confirmed each returned a non-zero exit status (expected failure) when run with `./target/debug/luna-rs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af5ff0fc08320bd3a5297769bccc8)