### PR TITLE
Implement int ranges in switch statements

### DIFF
--- a/src/compiler/emit.rs
+++ b/src/compiler/emit.rs
@@ -14,6 +14,7 @@ use crate::types;
 // https://github.com/bytecodealliance/wasmtime/blob/f6b2700cc89118308faadc08e72092642928f9cf/cranelift/frontend/src/switch.rs#L42
 struct SwitchEmitter {
     cases: HashMap<i64, BlockRef>,
+    range_cases: Vec<(i64, i64, BlockRef)>,
 }
 
 impl SwitchEmitter {
@@ -21,13 +22,19 @@ impl SwitchEmitter {
     pub fn new() -> Self {
         Self {
             cases: HashMap::new(),
+            range_cases: Vec::new(),
         }
     }
 
-    /// Set a switch entry
+    /// Set a switch entry for an exact integer value
     pub fn set_entry(&mut self, index: i64, block: BlockRef) {
         let prev = self.cases.insert(index, block);
         assert!(prev.is_none(), "Tried to set the same entry {index} twice");
+    }
+
+    /// Set a switch entry for an inclusive integer range [lo, hi]
+    pub fn set_range_entry(&mut self, lo: i64, hi: i64, block: BlockRef) {
+        self.range_cases.push((lo, hi, block));
     }
 
     /// Turn the `cases` `HashMap` into a list of `ContiguousCaseRange`s.
@@ -38,8 +45,8 @@ impl SwitchEmitter {
     /// * The `ContiguousCaseRange`s will not overlap.
     /// * Between two `ContiguousCaseRange`s there will be at least one entry index.
     /// * No `ContiguousCaseRange`s will be empty.
-    fn collect_contiguous_case_ranges(self) -> Vec<ContiguousCaseRange> {
-        let mut cases = self.cases.into_iter().collect::<Vec<(_, _)>>();
+    fn collect_contiguous_case_ranges(cases: HashMap<i64, BlockRef>) -> Vec<ContiguousCaseRange> {
+        let mut cases = cases.into_iter().collect::<Vec<(_, _)>>();
         cases.sort_by_key(|&(index, _)| index);
 
         let mut contiguous_case_ranges: Vec<ContiguousCaseRange> = vec![];
@@ -178,9 +185,25 @@ impl SwitchEmitter {
     /// * The function builder to emit to
     /// * The default block
     pub fn emit(self, bx: &mut FuncBuilder, default: BlockRef) {
-        let contiguous_case_ranges = self.collect_contiguous_case_ranges();
+        let SwitchEmitter { cases, range_cases } = self;
+        let contiguous_case_ranges = Self::collect_contiguous_case_ranges(cases);
         let temp = bx.create_temp(Type::Integer);
         bx.store(temp);
+
+        // Emit inclusive range checks as a linear chain before the exact-match dispatch
+        for (lo, hi, case_block) in range_cases {
+            let next_block = bx.new_block();
+            bx.load(temp);
+            bx.load_const_int(lo);
+            bx.geq_int();
+            bx.load(temp);
+            bx.load_const_int(hi);
+            bx.leq_int();
+            bx.and();
+            bx.condbr(case_block, next_block);
+            bx.switch_to_block(next_block);
+        }
+
         Self::build_search_tree(bx, temp, default, &contiguous_case_ranges);
     }
 }
@@ -830,11 +853,15 @@ impl<'a> FuncGen<'a> {
                         self.bld.switch_to_block(block);
                         did_return &= self.block_stmt(&case.block);
                         self.bld.br(finish_block);
-                        self.bld.switch_to_block(prev_block);
-
                         switch_emitter.set_entry(*i, block);
                     }
-                    ast::PatternKind::IntegerRange(_, _) => unimplemented!(),
+                    ast::PatternKind::IntegerRange(lo, hi) => {
+                        let block = self.bld.new_block();
+                        self.bld.switch_to_block(block);
+                        did_return &= self.block_stmt(&case.block);
+                        self.bld.br(finish_block);
+                        switch_emitter.set_range_entry(*lo, *hi, block);
+                    }
                     _ => {}
                 }
             }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -776,7 +776,14 @@ impl<'a> Parser<'a> {
         } else if self.test(TokenKind::IntegerLiteral) {
             let token = self.next()?;
             let value = token.get_int();
-            PatternKind::Integer(value)
+            if self.test(TokenKind::Punctuation(Punctuation::DotDot)) {
+                self.next()?;
+                let end_token = self.expect(TokenKind::IntegerLiteral)?;
+                let end_value = end_token.get_int();
+                PatternKind::IntegerRange(value, end_value)
+            } else {
+                PatternKind::Integer(value)
+            }
         } else if self.test(TokenKind::StringLiteral) {
             let token = self.next()?;
             let value = token.get_string();

--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -115,6 +115,7 @@ pub enum Punctuation {
     Colon,                                // :
     Comma,                                // ,
     Dot,                                  // .
+    DotDot,                               // ..
     DotDotDot,                            // ...
     Equals,                               // =
     EqualsEquals,                         // ==

--- a/src/compiler/tokeniser.rs
+++ b/src/compiler/tokeniser.rs
@@ -134,34 +134,40 @@ impl<'a> Tokeniser<'a> {
                     i64::from_str_radix(str, 8).unwrap(),
                 ))
             } else {
-                let str = self.source.accum(|c, _| c.is_numeric() || c == '.');
-                if str.contains('.') {
+                let int_str = self.source.accum(|c, _| c.is_numeric());
+                if self.source.peek_char() == Some('.') && !self.source.peek_str("..") {
+                    self.source.next();
+                    let dec_str = self.source.accum(|c, _| c.is_numeric());
+                    let float_str = format!("{}.{}", int_str, dec_str);
                     Some(Token::new_float(
                         loc,
                         TokenKind::NumberLiteral,
-                        str.parse().unwrap(),
+                        float_str.parse().unwrap(),
                     ))
                 } else {
                     Some(Token::new_int(
                         loc,
                         TokenKind::IntegerLiteral,
-                        i64::from_str_radix(str, 10).unwrap(),
+                        i64::from_str_radix(int_str, 10).unwrap(),
                     ))
                 }
             }
         } else if c.is_numeric() {
-            let str = self.source.accum(|c, _| c.is_numeric() || c == '.');
-            if str.contains('.') {
+            let int_str = self.source.accum(|c, _| c.is_numeric());
+            if self.source.peek_char() == Some('.') && !self.source.peek_str("..") {
+                self.source.next();
+                let dec_str = self.source.accum(|c, _| c.is_numeric());
+                let float_str = format!("{}.{}", int_str, dec_str);
                 Some(Token::new_float(
                     loc,
                     TokenKind::NumberLiteral,
-                    str.parse().unwrap(),
+                    float_str.parse().unwrap(),
                 ))
             } else {
                 Some(Token::new_int(
                     loc,
                     TokenKind::IntegerLiteral,
-                    i64::from_str_radix(str, 10).unwrap(),
+                    i64::from_str_radix(int_str, 10).unwrap(),
                 ))
             }
         } else if c == '\"' {
@@ -297,6 +303,9 @@ impl<'a> Tokeniser<'a> {
                     if self.source.peek_str("...") {
                         self.source.advance(3).unwrap();
                         Punctuation::DotDotDot
+                    } else if self.source.peek_str("..") {
+                        self.source.advance(2).unwrap();
+                        Punctuation::DotDot
                     } else {
                         self.source.next();
                         Punctuation::Dot
@@ -652,7 +661,7 @@ mod test {
 
     #[test]
     fn punctuation_tokens() {
-        let js = "& && &&= &= | || ||= |= ^ ^= : , . ...  = == === => ! != !== \
+        let js = "& && &&= &= | || ||= |= ^ ^= : , . .. ...  = == === => ! != !== \
         / /= < <= << <<= { [ ( - -= -- * *= ** **= % %= + += ++ ? ?? ??= > >= \
         >> >>= >>> >>>= } ] ) ; ~";
         let punctuation = &[
@@ -669,6 +678,7 @@ mod test {
             Punctuation::Colon,
             Punctuation::Comma,
             Punctuation::Dot,
+            Punctuation::DotDot,
             Punctuation::DotDotDot,
             Punctuation::Equals,
             Punctuation::EqualsEquals,

--- a/tests/success/stmt_switch_int_range.luna
+++ b/tests/success/stmt_switch_int_range.luna
@@ -1,0 +1,44 @@
+func main() {
+    let a = 5;
+    switch a {
+        1..10: {
+            assert(a >= 1 && a <= 10);
+        }
+        _: {
+            assert(false);
+        }
+    }
+    let b = 0;
+    switch b {
+        1..10: {
+            assert(false);
+        }
+        _: {
+            assert(b == 0);
+        }
+    }
+    let c = 3;
+    switch c {
+        1..2: {
+            assert(false);
+        }
+        3..5: {
+            assert(c >= 3 && c <= 5);
+        }
+        _: {
+            assert(false);
+        }
+    }
+    let d = 7;
+    switch d {
+        1..5: {
+            assert(false);
+        }
+        6: {
+            assert(false);
+        }
+        7..10: {
+            assert(d >= 7 && d <= 10);
+        }
+    }
+}


### PR DESCRIPTION
Add `1..10` range pattern syntax to switch statements. Ranges are handled inside SwitchEmitter via a linear comparison chain emitted before the exact-match jump table dispatch. Also fixes the tokeniser to stop consuming `..` as part of a float literal.